### PR TITLE
Replace deprecated lines() call with linesIterator() in thera.Thera

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,10 @@ project/plugins/project/
 .scala_dependencies
 .worksheet
 
+# IntelliJ IDEA specific
+.idea/
+.idea_modules/
+
 # Ensime
 /.ensime*
 

--- a/thera/src/thera/Thera.scala
+++ b/thera/src/thera/Thera.scala
@@ -10,8 +10,8 @@ object Thera extends Function1[String, Template] {
     }
 
   def split(src: String): (String, String) = {
-    val header = src.lines.drop(1).takeWhile(_ != "---").mkString("\n")
-    val body = src.lines.drop(1).dropWhile(_ != "---").drop(1).mkString("\n")
+    val header = src.linesIterator.drop(1).takeWhile(_ != "---").mkString("\n")
+    val body = src.linesIterator.drop(1).dropWhile(_ != "---").drop(1).mkString("\n")
     (header, body)
   }
 


### PR DESCRIPTION
This PR replaces deprecated `lines` call with `linesIterator` in `Thera.split()`.